### PR TITLE
Update version of node-soap to support node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "lodash": "^2.4.1",
-    "soap": "^0.6.0"
+    "soap": "^0.8.0"
   }
 }


### PR DESCRIPTION
I ran into https://github.com/vpulim/node-soap/issues/68.  Updating node-soap dependency to version 0.8.0 fixes the issue.
