### PR TITLE
fs - save retrieval as zip file

### DIFF
--- a/examples/retrieve-and-poll.js
+++ b/examples/retrieve-and-poll.js
@@ -2,6 +2,7 @@ var nforce   = require('nforce');
 var _        = require('lodash');
 var util     = require('util');
 var archiver = require('archiver');
+var fs = require('fs');
 
 require('../')(nforce);
 
@@ -37,9 +38,20 @@ org.authenticate().then(function(){
   });
 
   return promise;
+
 }).then(function(res) {
-  console.log('completed: ' + res.status);
-  console.log(res.zipFile);
+
+  console.log('retrieval: ' + res.status);
+  console.log('saving retrieval as zip file...');
+
+  var zipFileName = 'nforce-meta-retrieval-' + res.id + '.zip';
+
+  var buf = new Buffer(res.zipFile, 'base64');
+  fs.writeFile(zipFileName, buf, 'binary', function(err){
+        if (err) throw err
+  })
+  console.log('zip file saved.')
+
 }).error(function(err) {
   console.error(err);
 });


### PR DESCRIPTION
Adjusted 'retrieve-and-poll.js' example to produce a zip file.

It comes back from the API as base64, so just converting it to binary and then saving.

https://www.salesforce.com/us/developer/docs/api_meta/Content/meta_retrieveresult.htm
